### PR TITLE
Potential fix for issue #33 Losing focus doesn't update the overlay

### DIFF
--- a/lib/autocomplete_textfield.dart
+++ b/lib/autocomplete_textfield.dart
@@ -180,6 +180,10 @@ class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
 
       if (!textField.focusNode.hasFocus) {
         filteredSuggestions = [];
+        updateOverlay();
+      }
+      else if(!(currentText == "" || currentText == null)){
+        updateOverlay(currentText);
       }
     });
   }


### PR DESCRIPTION
Losing focus to another widget doesn't cause the suggestions overlay to hide. Added functionality once widget gains focus to display the correct suggestions.