### PR TITLE
Make TextField unfocus optional on itemSubmitted

### DIFF
--- a/lib/autocomplete_textfield.dart
+++ b/lib/autocomplete_textfield.dart
@@ -22,7 +22,7 @@ class AutoCompleteTextField<T> extends StatefulWidget {
   final AutoCompleteOverlayItemBuilder<T> itemBuilder;
   final int suggestionsAmount;
   final GlobalKey<AutoCompleteTextFieldState<T>> key;
-  final bool submitOnSuggestionTap, clearOnSubmit;
+  final bool submitOnSuggestionTap, clearOnSubmit, unFocusOnItemSubmitted;
   final List<TextInputFormatter> inputFormatters;
   final int minLength;
 
@@ -63,7 +63,8 @@ class AutoCompleteTextField<T> extends StatefulWidget {
       this.textCapitalization: TextCapitalization.sentences,
       this.minLength = 1,
       this.controller,
-      this.focusNode})
+      this.focusNode,
+      this.unFocusOnItemSubmitted = true})
       : super(key: key);
 
   void clear() => key.currentState.clear();
@@ -112,7 +113,8 @@ class AutoCompleteTextField<T> extends StatefulWidget {
       keyboardType,
       textInputAction,
       controller,
-      focusNode);
+      focusNode,
+      unFocusOnItemSubmitted);
 }
 
 class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
@@ -130,7 +132,7 @@ class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
   Filter<T> itemFilter;
   int suggestionsAmount;
   int minLength;
-  bool submitOnSuggestionTap, clearOnSubmit;
+  bool submitOnSuggestionTap, clearOnSubmit, unFocusOnItemSubmitted;
   TextEditingController controller;
   FocusNode focusNode;
 
@@ -163,7 +165,8 @@ class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
       this.keyboardType,
       this.textInputAction,
       this.controller,
-      this.focusNode) {
+      this.focusNode,
+      this.unFocusOnItemSubmitted) {
     textField = new TextField(
       inputFormatters: inputFormatters,
       textCapitalization: textCapitalization,
@@ -323,7 +326,9 @@ class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
                                       if (submitOnSuggestionTap) {
                                         String newText = suggestion.toString();
                                         textField.controller.text = newText;
-                                        textField.focusNode.unfocus();
+                                        if (unFocusOnItemSubmitted) {
+                                          textField.focusNode.unfocus();
+                                        }
                                         itemSubmitted(suggestion);
                                         if (clearOnSubmit) {
                                           clear();
@@ -447,5 +452,6 @@ class SimpleAutoCompleteTextField extends AutoCompleteTextField<String> {
           keyboardType,
           textInputAction,
           controller,
-          focusNode);
+          focusNode,
+          unFocusOnItemSubmitted);
 }


### PR DESCRIPTION
This adds an option to disable the unfocus of the TextField when choosing a suggestion (I left the default to regular behavior).
I need this option because I have a "tags" TextField where you can add multiple tags.