### PR TITLE
Remove overlay on dispose

### DIFF
--- a/lib/autocomplete_textfield.dart
+++ b/lib/autocomplete_textfield.dart
@@ -372,6 +372,7 @@ class AutoCompleteTextFieldState<T> extends State<AutoCompleteTextField> {
     if (controller == null) {
       textField.controller.dispose();
     }
+    listSuggestionsEntry?.remove();
     super.dispose();
   }
 


### PR DESCRIPTION
From issue: https://github.com/felixlucien/flutter-autocomplete-textfield/issues/37